### PR TITLE
Fixup for the MSBuild.Gulp package.

### DIFF
--- a/nuget/MSBuild.Gulp.nuspec
+++ b/nuget/MSBuild.Gulp.nuspec
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <id>MSBuild.Node</id>
-    <title>MSBuild.Node</title>
+    <id>MSBuild.Gulp</id>
+    <title>MSBuild.Gulp</title>
     <version>0.2.0</version>
     <authors>Kevin Mees</authors>
     <owners>Kevin Mees</owners>


### PR DESCRIPTION
The gulp package had its output set to MSBuild.Node, effectively overwriting the MSBuild.Node package in the build output.
