### PR TITLE
Wrapping grunt task in quotes to prevent broken builds.

### DIFF
--- a/build/MSBuild.Grunt.targets
+++ b/build/MSBuild.Grunt.targets
@@ -27,8 +27,8 @@
         </PropertyGroup>
 
         <PropertyGroup>
-            <RunGruntBuildCmd>$(EnsureNodeInPathCmd) "$(GruntExecutable)" --no-color --gruntfile "$(GruntFile)" $(GruntBuildTask) > "$(GruntOut)"</RunGruntBuildCmd>
-            <RunGruntCleanCmd>$(EnsureNodeInPathCmd) "$(GruntExecutable)" --no-color --gruntfile "$(GruntFile)" $(GruntCleanTask) > "$(GruntOut)"</RunGruntCleanCmd>
+            <RunGruntBuildCmd>$(EnsureNodeInPathCmd) "$(GruntExecutable)" --no-color --gruntfile "$(GruntFile)" "$(GruntBuildTask)" > "$(GruntOut)"</RunGruntBuildCmd>
+            <RunGruntCleanCmd>$(EnsureNodeInPathCmd) "$(GruntExecutable)" --no-color --gruntfile "$(GruntFile)" "$(GruntCleanTask)" > "$(GruntOut)"</RunGruntCleanCmd>
 
             <GruntBuildTaskError>Error running grunt task '$(GruntBuildTask)'. See Warnings for details.</GruntBuildTaskError>
             <GruntCleanTaskError>Error running grunt task '$(GruntCleanTask)'. See Warnings for details.</GruntCleanTaskError>


### PR DESCRIPTION
Grunt tasks with names ending in a closing parenthesis, such as "build-Debug_(WithLogging)", cause Grunt to new line after completing the task. This behavior causes builds to fail (due to an "error running grunt task...") even though the grunt task completes successfully without errors. Wapping the task in quotes prevents this issue.