### PR TITLE
Set ConsoleToMsBuild during execution of where.exe to locate grunt.cmd.

### DIFF
--- a/build/MSBuild.Grunt.targets
+++ b/build/MSBuild.Grunt.targets
@@ -13,6 +13,7 @@
         <Exec Command="$(WINDIR)\system32\where.exe grunt"
             ContinueOnError="true"
             IgnoreExitCode="true"
+            ConsoleToMsBuild="true"
             Condition=" !Exists('$(GruntExecutable)') ">
             <Output TaskParameter="ExitCode" PropertyName="GruntExitCode" />
             <Output TaskParameter="ConsoleOutput" PropertyName="GruntExecutable" />


### PR DESCRIPTION
Fix error to locate grunt.cmd as described in this issue #27.
