### PR TITLE
Fix working directory For Gulp

### DIFF
--- a/build/MSBuild.Gulp.targets
+++ b/build/MSBuild.Gulp.targets
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <Target Name="EnsureGulp">
         <PropertyGroup>
@@ -44,8 +44,7 @@
         <Exec Command="$(RunGulpBuildCmd)"
             ContinueOnError="true"
             IgnoreExitCode="true"
-            ConsoleToMsBuild="true"
-            WorkingDirectory="$(GulpWorkingDirectory)" >
+            ConsoleToMsBuild="true" >
             <Output TaskParameter="ExitCode" PropertyName="GulpExitCode"/>
         </Exec>
         <ReadLinesFromFile File="$(GulpOut)">
@@ -64,8 +63,7 @@
         <Exec Command="$(RunGulpCleanCmd)"
             ContinueOnError="true"
             IgnoreExitCode="true"
-            ConsoleToMsBuild="true"
-            WorkingDirectory="$(GulpWorkingDirectory)" >
+            ConsoleToMsBuild="true" >
             <Output TaskParameter="ExitCode" PropertyName="GulpExitCode"/>
         </Exec>
         <ReadLinesFromFile File="$(GulpOut)">


### PR DESCRIPTION
The WorkingDirectory was set by the <Exec/> task AND by gulp (--cwd). When the WorkingDirectory was completely different from the current directory, this made the gulpfile totally unfindable.
On execution, it was looking for the gulpfile in 'workingdirectory/workingdirectory/gulpfile.js'.

Fixes #35 
