### PR TITLE
Update MSBuild.Gulp.targets

### DIFF
--- a/build/MSBuild.Gulp.targets
+++ b/build/MSBuild.Gulp.targets
@@ -10,7 +10,7 @@
         </PropertyGroup>
         <Message Text="Ensuring Gulp is installed" Importance="low" />
 
-        <Exec Command="$(WINDIR)\system32\where.exe gulp"
+        <Exec Command="$(WINDIR)\system32\where.exe gulp.cmd"
             ContinueOnError="true"
             IgnoreExitCode="true"
             Condition=" !Exists('$(GulpExecutable)') ">

--- a/build/MSBuild.Gulp.targets
+++ b/build/MSBuild.Gulp.targets
@@ -13,6 +13,7 @@
         <Exec Command="$(WINDIR)\system32\where.exe gulp.cmd"
             ContinueOnError="true"
             IgnoreExitCode="true"
+            ConsoleToMsBuild="true"
             Condition=" !Exists('$(GulpExecutable)') ">
             <Output TaskParameter="ExitCode" PropertyName="GulpExitCode"/>
             <Output TaskParameter="ConsoleOutput" PropertyName="GulpExecutable" />


### PR DESCRIPTION
If node global module path is not the default one ($(HOMEDRIVE)$(HOMEPATH)\AppData\Roaming\npm) that is declared in MSBuild.Node.props file then gulp taks will fail by 2 causes .
1) Where.exe gulp returns 2 results
2) ConsoleToMsBuild property is not true 

Issue :https://github.com/kmees/MSBuild.NodeTools/issues/37
