### PR TITLE
Redirect stderr to nul device for npm config get prefix

### DIFF
--- a/build/MSBuild.Node.targets
+++ b/build/MSBuild.Node.targets
@@ -37,7 +37,7 @@
             <UnknownNodeModulePath>Global node modules not found. Please set the 'LocalNodeModulePath' property in your project file.</UnknownNodeModulePath>
             <InvalidGlobalNodeModulePath>Invalid global node module path.</InvalidGlobalNodeModulePath>
             <InvalidLocalNodeModulePath>Invalid local node module path.</InvalidLocalNodeModulePath>
-            <NpmGetPrefix>""$(NodePath)\npm.cmd" config get prefix"</NpmGetPrefix>
+            <NpmGetPrefix>""$(NodePath)\npm.cmd" config get prefix 2&gt; nul"</NpmGetPrefix>
         </PropertyGroup>
         <Message Text="Ensuring global npm path" Importance="low" />
 


### PR DESCRIPTION
Redirect stderr into nul for the npm 'config get prefix' command so errors or warnings on stderr don't pollute the 'NpmGetPrefix' variable.