### PR TITLE
Remove use of HOMEDRIVE and HOMEPATH

### DIFF
--- a/build/MSBuild.Node.props
+++ b/build/MSBuild.Node.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <GlobalNodePath>$(NODEJS)</GlobalNodePath>
-        <GlobalNodeModulePath>$(HOMEDRIVE)$(HOMEPATH)\AppData\Roaming\npm</GlobalNodeModulePath>
+        <GlobalNodeModulePath>$(USERPROFILE)\AppData\Roaming\npm</GlobalNodeModulePath>
         <LocalNodePath></LocalNodePath>
         <LocalNodeModulePath></LocalNodeModulePath>
         <NodePath>$(GlobalNodePath)</NodePath>


### PR DESCRIPTION
As described in issue #47 HOMEDRIVE and HOMEPATH are volatile variables that shouldn't be used.
I replace these variables with the non-volatile variable USERPROFILE.

Question: does this task also has to work in Linux systems?

fixes #47